### PR TITLE
🩹 [Patch]: Fix path separator in action.yml script execution

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -29,4 +29,4 @@ runs:
         GITHUB_ACTION_INPUT_PrivateKey: ${{ inputs.PrivateKey }}
       run: |
         # Get-AppJWT
-        ${{ github.action_path }}\scripts\main.ps1
+        ${{ github.action_path }}/scripts/main.ps1


### PR DESCRIPTION
## Description

This pull request includes a small change to the `action.yml` file. The change corrects the path separator in the `run` command to use a forward slash instead of a backslash.

* `action.yml`:
  * Corrected the path separator in the `run` command from a backslash to a forward slash.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
